### PR TITLE
Remove hardcoded primary key values

### DIFF
--- a/blog/tests.py
+++ b/blog/tests.py
@@ -94,7 +94,7 @@ class TestView(TestCase):
         main_area = soup.find('div', id='main-area')
         self.assertNotIn('아직 게시물이 없습니다', main_area.text)
 
-        post_001_card = main_area.find('div', id='post-1')  # id가 post-1인 div를 찾아서, 그 안에
+        post_001_card = main_area.find('div', id=f'post-{self.post_001.pk}')  # id가 post-1인 div를 찾아서, 그 안에
         self.assertIn(self.post_001.title, post_001_card.text)  # title이 있는지
         self.assertIn(self.post_001.category.name, post_001_card.text)  # category가 있는지
         self.assertIn(self.post_001.author.username.upper(), post_001_card.text)  # 작성자명이 있는지
@@ -102,7 +102,7 @@ class TestView(TestCase):
         self.assertNotIn(self.tag_python.name, post_001_card.text)
         self.assertNotIn(self.tag_python_kor.name, post_001_card.text)
 
-        post_002_card = main_area.find('div', id='post-2')
+        post_002_card = main_area.find('div', id=f'post-{self.post_002.pk}')
         self.assertIn(self.post_002.title, post_002_card.text)
         self.assertIn(self.post_002.category.name, post_002_card.text)
         self.assertIn(self.post_002.author.username.upper(), post_002_card.text)
@@ -110,7 +110,7 @@ class TestView(TestCase):
         self.assertNotIn(self.tag_python.name, post_002_card.text)
         self.assertNotIn(self.tag_python_kor.name, post_002_card.text)
 
-        post_003_card = main_area.find('div', id='post-3')
+        post_003_card = main_area.find('div', id=f'post-{self.post_003.pk}')
         self.assertIn('미분류', post_003_card.text)
         self.assertIn(self.post_003.title, post_003_card.text)
         self.assertIn(self.post_003.author.username.upper(), post_003_card.text)
@@ -127,7 +127,7 @@ class TestView(TestCase):
         self.assertIn('아직 게시물이 없습니다', main_area.text)
 
     def test_post_detail(self):
-        self.assertEqual(self.post_001.get_absolute_url(), '/blog/1/')
+        self.assertEqual(self.post_001.get_absolute_url(), f'/blog/{self.post_001.pk}/')
 
         response = self.client.get(self.post_001.get_absolute_url())
         self.assertEqual(response.status_code, 200)
@@ -152,7 +152,7 @@ class TestView(TestCase):
 
         # comment area
         comments_area = soup.find('div', id='comment-area')
-        comment_001_area = comments_area.find('div', id='comment-1')
+        comment_001_area = comments_area.find('div', id=f'comment-{self.comment_001.pk}')
         self.assertIn(self.comment_001.author.username, comment_001_area.text)
         self.assertIn(self.comment_001.content, comment_001_area.text)
 
@@ -341,8 +341,8 @@ class TestView(TestCase):
         soup = BeautifulSoup(response.content, 'html.parser')
 
         comment_area = soup.find('div', id='comment-area')
-        self.assertFalse(comment_area.find('a', id='comment-1-update-btn'))
-        self.assertFalse(comment_area.find('a', id='comment-2-update-btn'))
+        self.assertFalse(comment_area.find('a', id=f'comment-{self.comment_001.pk}-update-btn'))
+        self.assertFalse(comment_area.find('a', id=f'comment-{comment_by_trump.pk}-update-btn'))
 
         # 로그인 한 상태
         self.client.login(username='obama', password='somepassword')
@@ -351,12 +351,12 @@ class TestView(TestCase):
         soup = BeautifulSoup(response.content, 'html.parser')
 
         comment_area = soup.find('div', id='comment-area')
-        self.assertFalse(comment_area.find('a', id='comment-2-update-btn'))
-        comment_001_update_btn = comment_area.find('a', id='comment-1-update-btn')
+        self.assertFalse(comment_area.find('a', id=f'comment-{comment_by_trump.pk}-update-btn'))
+        comment_001_update_btn = comment_area.find('a', id=f'comment-{self.comment_001.pk}-update-btn')
         self.assertIn('edit', comment_001_update_btn.text)
-        self.assertEqual(comment_001_update_btn.attrs['href'], '/blog/update_comment/1/')
+        self.assertEqual(comment_001_update_btn.attrs['href'], f'/blog/update_comment/{self.comment_001.pk}/')
 
-        response = self.client.get('/blog/update_comment/1/')
+        response = self.client.get(f'/blog/update_comment/{self.comment_001.pk}/')
         self.assertEqual(response.status_code, 200)
         soup = BeautifulSoup(response.content, 'html.parser')
 
@@ -375,7 +375,7 @@ class TestView(TestCase):
 
         self.assertEqual(response.status_code, 200)
         soup = BeautifulSoup(response.content, 'html.parser')
-        comment_001_div = soup.find('div', id='comment-1')
+        comment_001_div = soup.find('div', id=f'comment-{self.comment_001.pk}')
         self.assertIn('오바마의 댓글을 수정합니다.', comment_001_div.text)
         self.assertIn('Updated: ', comment_001_div.text)
 
@@ -395,8 +395,8 @@ class TestView(TestCase):
         soup = BeautifulSoup(response.content, 'html.parser')
 
         comment_area = soup.find('div', id='comment-area')
-        self.assertFalse(comment_area.find('a', id='comment-1-delete-btn'))
-        self.assertFalse(comment_area.find('a', id='comment-2-delete-btn'))
+        self.assertFalse(comment_area.find('a', id=f'comment-{self.comment_001.pk}-delete-btn'))
+        self.assertFalse(comment_area.find('a', id=f'comment-{comment_by_trump.pk}-delete-btn'))
 
         # trump로 로그인 한 상태
         self.client.login(username='trump', password='somepassword')
@@ -405,26 +405,26 @@ class TestView(TestCase):
         soup = BeautifulSoup(response.content, 'html.parser')
 
         comment_area = soup.find('div', id='comment-area')
-        self.assertFalse(comment_area.find('a', id='comment-1-delete-btn'))
+        self.assertFalse(comment_area.find('a', id=f'comment-{self.comment_001.pk}-delete-btn'))
         comment_002_delete_modal_btn = comment_area.find(
-            'a', id='comment-2-delete-modal-btn'
+            'a', id=f'comment-{comment_by_trump.pk}-delete-modal-btn'
         )
         self.assertIn('delete', comment_002_delete_modal_btn.text)
         self.assertEqual(
             comment_002_delete_modal_btn.attrs['data-target'],
-            '#deleteCommentModal-2'
+            f'#deleteCommentModal-{comment_by_trump.pk}'
         )
 
-        delete_comment_modal_002 = soup.find('div', id='deleteCommentModal-2')
+        delete_comment_modal_002 = soup.find('div', id=f'deleteCommentModal-{comment_by_trump.pk}')
         self.assertIn('Are You Sure?', delete_comment_modal_002.text)
         really_delete_btn_002 = delete_comment_modal_002.find('a')
         self.assertIn('Delete', really_delete_btn_002.text)
         self.assertEqual(
             really_delete_btn_002.attrs['href'],
-            '/blog/delete_comment/2/'
+            f'/blog/delete_comment/{comment_by_trump.pk}/'
         )
 
-        response = self.client.get('/blog/delete_comment/2/', follow=True)
+        response = self.client.get(f'/blog/delete_comment/{comment_by_trump.pk}/', follow=True)
         self.assertEqual(response.status_code, 200)
         soup = BeautifulSoup(response.content, 'html.parser')
         self.assertIn(self.post_001.title, soup.title.text)


### PR DESCRIPTION
## 목적
Blog 테스트 코드를 수정하여, 사용하는 데이터베이스에 상관없이 동작하도록 합니다.

## 주요 변경사항
- 하드코드 된 pk값 변경
  현재 테스트코드는 pk 값이 하드코딩 되어있는 부분이 있습니다. 이는, SQLite 를 데이터베이스로 연결했을 때는 잘 동작합니다.
  하지만 PostgreSQL의 경우 SQLite와 동작방식이 다르기 때문에 에러가 납니다.
  따라서, 하드코드된 pk 값을 제거하여, 데이터베이스에 indepedent하게 동작하도록 합니다.



